### PR TITLE
Add support for overriding main function

### DIFF
--- a/src/lib/gen.sh
+++ b/src/lib/gen.sh
@@ -208,7 +208,13 @@ function generateCli() {
     if [[ "$BUILD_HELP" == "yes" ]]; then buildHelpFunction "$cliScripts"; fi
     buildVersionFunction
     buildCliFooter
-    print_out "__run \"\$@\""
+
+    if [ -e "$SRC_PATH/main.sh" ]; then
+        genInclude "main.sh";
+    else
+        print_out "__run \"\$@\""
+    fi;
+
     print_out 'export __STATUS="$?"'
     sep
     cd "$CWD";


### PR DESCRIPTION
This pull request adds the option to define the scripts' main function (the one handled by default by `__run`, IIRC).

This option comes handy when you have developed a script and it already handles options and such, and you want your script to handle them.
