### PR TITLE
Fix compacting empty lines

### DIFF
--- a/src/lib/io.sh
+++ b/src/lib/io.sh
@@ -38,7 +38,11 @@ function nl() {
 # This always writes to stdout
 function includeBashFile() {
     if [ -s "$1" ] && bash -n "$1"; then
-        if [[ "$COMPACT" != "yes" ]]; then echo "# $1"; fi; 
-        sed '/^\s*#.*$/d' "$1" | sed '/^\s*$/d';
+        if [[ "$COMPACT" == "yes" ]]; then
+            sed '/^\s*#.*$/d' "$1" | sed '/^\s*$/d';
+        else
+            echo "# $1";
+            sed '/^\s*#.*$/d' "$1";
+        fi;
     fi
 }


### PR DESCRIPTION
This pull request fixes the default behavior of compacting empty lines (with `--compact` and without it).

I often format the output of my scripts in a way that it's easy to read (with lots of paragraphs and empty lines) and the default behavior was messing with it.
