### PR TITLE
Support `set -u` on init.sh and before-task.sh

### DIFF
--- a/src/lib/gen.sh
+++ b/src/lib/gen.sh
@@ -136,8 +136,8 @@ function buildCliHeader() {
     print_out '  local pid=""'
     print_out '  local status=255'
     genInclude "before-task.sh" "  "
-    print_out '  local cmd="$1"'
-    print_out '  shift'
+    print_out '  local cmd="${1-}"'
+    print_out '  shift || true'
     print_out '  case "$cmd" in'
     print_out '    "") __run "help"; return $?;;'
 }
@@ -240,7 +240,7 @@ function generateStandaloneTask() {
     genInclude "init.sh"
     generateLibrary
     genInclude "before-task.sh"
-    print_out 'shift'
+    print_out 'shift || true'
     print_out 'function __run() { echo "__run not available when running CLI task directly!" 1>&2; exit 1; }'
     if [ -e "$CLI_PATH/$task" ]; then genInclude "tasks/$task";
     else genInclude "hidden-tasks/$task"; fi


### PR DESCRIPTION
fix for "unbound variable" error when I use `set -u` on init.sh or before-task.sh

``` sh
$ bashing new foo
Initializing ./foo ...
Successfully initialized './foo'.
$ cd foo
$ echo 'set -u' > src/init.sh
$ bashing deploy
Creating /home/kui/toybox/foo/target/foo-0.1.0-SNAPSHOT.sh ...
Uberbash created successfully.
Deploying to /home/kui/toybox/foo/bin/foo ...
Deployed successfully.
$ bin/foo
bin/foo: line 20: $1: unbound variable
```
