### PR TITLE
Change shebang to env reference

### DIFF
--- a/bin/bashing
+++ b/bin/bashing
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ---------------------------------------------
 # Artifact:     bashing/bashing
 # Version:      0.2.1
@@ -55,7 +55,7 @@ function magenta() { colorize "${MAGENTA}" "${@}"; }
 function cyan() { colorize "${CYAN}" "${@}"; }
 function white() { colorize "${WHITE}" "${@}"; }
 function generateHeader() {
-    print_out "#!/bin/bash"
+    print_out "#!/usr/bin/env bash"
     sep
     print_out "# $(head -c 45 /dev/zero | tr '\0' '-')";
     print_out "# Artifact:     $GROUP_ID/$ARTIFACT_ID"
@@ -401,7 +401,7 @@ function cli_new() {
   echo "YOUR DESCRIPTION HERE." >> "$PROJ"
   path="$TASKS/hello.sh"
   if ! touch "$path"; then fatal "Could not create File: $path"; fi
-  echo "#!/bin/bash" > "$path"
+  echo "#!/usr/bin/env bash" > "$path"
   echo "" >> "$path"
   echo "# Run with: 'bashing run hello'" >> "$path"
   echo "" >> "$path" >> "$path"
@@ -467,7 +467,7 @@ function cli_uberbash() {
   fi
   if [[ "$COMPRESS" == "yes" ]]; then
       verbose "Compressing into $TARGET_FILE_COMPRESSED ..."
-      echo "#!/bin/bash" > "$TARGET_FILE_COMPRESSED"
+      echo "#!/usr/bin/env bash" > "$TARGET_FILE_COMPRESSED"
       echo 'tail -n +3 "$0" | gzip -d -n 2> /dev/null | bash -s "$@"; exit $?' >> "$TARGET_FILE_COMPRESSED"
       gzip -c -n "$TARGET_FILE" >> "$TARGET_FILE_COMPRESSED";
       if [[ "$?" != "0" ]]; then fatal "An error occured while running task 'compile'."; fi
@@ -555,7 +555,7 @@ function cli_new_task() {
   if ! mkdir -p "$dir"; then fatal "Could not create Directory: $dir"; fi
   if [ -e "$path" ]; then fatal "File does already exist: $path"; fi
   if ! touch "$path"; then fatal "Could not create File: $path"; fi
-  echo "#!/bin/bash" > "$path"
+  echo "#!/usr/bin/env bash" > "$path"
   echo "" >> "$path"
   echo "# Run with: 'bashing run $task'" >> "$path"
   echo "" >> "$path" >> "$path"

--- a/src/before-task.sh
+++ b/src/before-task.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generate Config Dir
 mkdir -p "$SETTINGS_DIR" 2> /dev/null || fatal "Could not initialize directory: $SETTINGS_DIR";

--- a/src/hidden-tasks/compile.sh
+++ b/src/hidden-tasks/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #!require log
 #!require io

--- a/src/hidden-tasks/deploy.sh
+++ b/src/hidden-tasks/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # <help>create uberbash and copy to deploy path</help>
 

--- a/src/hidden-tasks/new/task.sh
+++ b/src/hidden-tasks/new/task.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Parameters
 task="$1"
@@ -17,7 +17,7 @@ if ! mkdir -p "$dir"; then fatal "Could not create Directory: $dir"; fi
 if [ -e "$path" ]; then fatal "File does already exist: $path"; fi
 if ! touch "$path"; then fatal "Could not create File: $path"; fi
 
-echo "#!/bin/bash" > "$path"
+echo "#!/usr/bin/env bash" > "$path"
 echo "" >> "$path"
 echo "# Run with: 'bashing run $task'" >> "$path"
 echo "" >> "$path" >> "$path"

--- a/src/hidden-tasks/remote/add.sh
+++ b/src/hidden-tasks/remote/add.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 name="$1"
 repo="$2"

--- a/src/hidden-tasks/remote/install.sh
+++ b/src/hidden-tasks/remote/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 name="$1"
 repo="$2"

--- a/src/hidden-tasks/remote/remove.sh
+++ b/src/hidden-tasks/remote/remove.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 name="$1"
 

--- a/src/lib/colorize.sh
+++ b/src/lib/colorize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generic Colorize Functions
 

--- a/src/lib/gen.sh
+++ b/src/lib/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #!require io
 
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------
 # Header
 function generateHeader() {
-    print_out "#!/bin/bash"
+    print_out "#!/usr/bin/env bash"
     sep
     print_out "# $(head -c 45 /dev/zero | tr '\0' '-')";
     print_out "# Artifact:     $GROUP_ID/$ARTIFACT_ID"

--- a/src/lib/io.sh
+++ b/src/lib/io.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ----------------------------------------------------------------
 # Write Functions for bashing. They check if a variable $OUT is set,

--- a/src/lib/log.sh
+++ b/src/lib/log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #!require colorize
 
 # Generic Logging Functions

--- a/src/lib/metadata.sh
+++ b/src/lib/metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Read metadata from source files. Metadata is identified by
 # XML tags in commented lines.

--- a/src/lib/project.sh
+++ b/src/lib/project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Project File Examination
 

--- a/src/tasks/clean.sh
+++ b/src/tasks/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # <help>remove build results and cached data</help>
 

--- a/src/tasks/install.sh
+++ b/src/tasks/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # <help>deploy uberbash at $HOME/.bin</help>
 

--- a/src/tasks/new.sh
+++ b/src/tasks/new.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # <help>initialize directories for a bashing project</help>
 
@@ -43,7 +43,7 @@ echo "YOUR DESCRIPTION HERE." >> "$PROJ"
 
 path="$TASKS/hello.sh"
 if ! touch "$path"; then fatal "Could not create File: $path"; fi
-echo "#!/bin/bash" > "$path"
+echo "#!/usr/bin/env bash" > "$path"
 echo "" >> "$path"
 echo "# Run with: 'bashing run hello'" >> "$path"
 echo "" >> "$path" >> "$path"

--- a/src/tasks/remote.sh
+++ b/src/tasks/remote.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # <help>handle remote bashing applications</help>
 
 subtask="$1"

--- a/src/tasks/run.sh
+++ b/src/tasks/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # <help>run task in the project's context</help>
 
 # Run CLI script in context of Library, Setup and Shutdown.

--- a/src/tasks/uberbash.sh
+++ b/src/tasks/uberbash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # <help>create standalone bash script</help>
 
@@ -39,7 +39,7 @@ fi
 
 if [[ "$COMPRESS" == "yes" ]]; then
     verbose "Compressing into $TARGET_FILE_COMPRESSED ..."
-    echo "#!/bin/bash" > "$TARGET_FILE_COMPRESSED"
+    echo "#!/usr/bin/env bash" > "$TARGET_FILE_COMPRESSED"
     echo 'tail -n +3 "$0" | gzip -d -n 2> /dev/null | bash -s "$@"; exit $?' >> "$TARGET_FILE_COMPRESSED"
     gzip -c -n "$TARGET_FILE" >> "$TARGET_FILE_COMPRESSED";
     if [[ "$?" != "0" ]]; then fatal "An error occured while running task 'compile'."; fi

--- a/src/tasks/version.sh
+++ b/src/tasks/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # <help>display version</help>
 


### PR DESCRIPTION
Using `#!/usr/bin/env bash` instead of `#!/bin/bash` searches `$PATH` for bash instead of assuming it's located in `/bin`. This can occur on systems other than Linux, if ti's been renamed, or if a newer/preferred version of bash is installed elsewhere, and would occur earlier in the `$PATH`.